### PR TITLE
Deprecated use of config

### DIFF
--- a/src/Model/Behavior/CreatorModifierBehavior.php
+++ b/src/Model/Behavior/CreatorModifierBehavior.php
@@ -62,7 +62,7 @@ class CreatorModifierBehavior extends Behavior {
 	 */
 	public function initialize(array $config) {
 		if (isset($config['events'])) {
-			$this->config('events', $config['events'], false);
+			$this->setConfig('events', $config['events'], false);
 		}
 	}
 


### PR DESCRIPTION
On line 65 was replaced $this->config with $this->setConfig to fix deprecated use of this method with new Cake 3.6